### PR TITLE
Feature/build a version of Aphex that has PHP 7.4

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,54 @@
+name: Build Aphex
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+env:
+  IMAGE_NAME: ethicaljobs/aphex
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.3', '7.4']
+    name: Build PHP ${{ matrix.php }} container
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Retrieve Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ethicaljobs/aphex-php${{ matrix.php }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push container
+        uses: docker/build-push-action@v1
+        with:
+          context: .
+          push: true
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=inline
+          cache-to: type=inline

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,12 +43,13 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push container
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           build-args: |
             PHP_VERSION=${{ matrix.php }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=inline
           cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.3-fpm-alpine3.10 AS php
+ARG PHP_VERSION=7.3
+FROM php:$PHP_VERSION-fpm-alpine3.10 AS php
 
 LABEL maintainer="Ethical Jobs <development@ethicaljobs.com.au>"
 
@@ -6,16 +7,13 @@ FROM php AS php_modules
 
 RUN apk --no-cache add \
         freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev \
+        oniguruma-dev \
         wget \
         git \
         supervisor \
         bash \
     && NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
     && docker-php-ext-configure gd \
-        --with-gd \
-        --with-freetype-dir=/usr/include/ \
-        --with-png-dir=/usr/include/ \
-        --with-jpeg-dir=/usr/include/ \
     && pecl install xdebug && pecl clear-cache \
     && docker-php-ext-install -j${NPROC} \
         mysqli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apk --no-cache add \
 FROM php AS composer
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
-    && composer global require --prefer-dist --no-suggest --no-progress "hirak/prestissimo" \
     && composer global clear-cache
 
 FROM php_modules AS aphex


### PR DESCRIPTION
Aphex bundles a lot of stuff together that you don't always need, such as plopping both Nginx and PHP-FPM into the same container. But sometimes you do need that - Laravel Nova for example requires both. And we want to use PHP 7.4 moving forward for our Nova repo, which means we want a Docker container that has Aphex's bundling. So, Aphex with PHP 7.4 in it it is! This should work, I hope?